### PR TITLE
Remove call to __del__

### DIFF
--- a/python/lsst/ci/ctio0m9/validate.py
+++ b/python/lsst/ci/ctio0m9/validate.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import atexit
 import sys
 import traceback
 
@@ -14,14 +15,14 @@ class TestTask(CmdLineTask):
     ConfigClass = Config  # Nothing to configure!
 
     def __init__(self, *args, **kwargs):
-        super(TestTask, self).__init__(*args, **kwargs)
+        CmdLineTask.__init__(self, *args, **kwargs)
         self._failures = 0
+        atexit.register(self.finalise)
 
-    def __del__(self):
+    def finalise(self):
         if self._failures > 0:
             self.log.fatal("%d tests failed")
             sys.exit(1)
-        CmdLineTask.__del__(self)
 
     @classmethod
     def _makeArgumentParser(cls):


### PR DESCRIPTION
Move logic to a finalise() method, as __del__ is always called in py3
but this is not the case in py2. Also, remove the call to super()
as it was unnecessary and this way is equivalent but safer.